### PR TITLE
Distribute geohash-min.js

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,5 +2,5 @@
   "name": "geohash",
   "version": "1.0.0",
   "main": "geohash.js",
-  "ignore": ["geohash-min.js", "docs", "test", "*.yml", "*.map"]
+  "ignore": ["docs", "test", "*.yml", "*.map"]
 }


### PR DESCRIPTION
I can't see any good reason not to distribute the minified version of geohash, but it could be useful for some people. 
